### PR TITLE
ibrowse: enable inet6 from upstream

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -532,7 +532,7 @@ is_ipv6_host(Host) ->
         {ok, {_, _, _, _}} ->
             false;
         _  ->
-            case inet:gethostbyname(Host) of
+            case inet:gethostbyname(Host, inet6) of
                 {ok, #hostent{h_addrtype = inet6}} ->
                     true;
                 _ ->


### PR DESCRIPTION
presently it's not possible to use ibrowse client (e.g. during replication) for
inet6-only hosts as the pattern match returned is insufficient. This patch
pulls in upstream's https://github.com/cmullaparthi/ibrowse/commit/555f7074
minimal diff.

The patch will also require tagging so we can pull it into the main couchdb
tree, I've suggested CouchDB-4.0.2 which doesn't quite line up with the
history from ibrowse but it seems sensible enough.

```erl
Eshell V9.3.3.3  (abort with ^G)
1> inet:gethostbyname("wintermute.skunkwerks.at").
{error,nxdomain}
2> inet:gethostbyname("wintermute.skunkwerks.at", inet6).
{ok,{hostent,"wintermute.skunkwerks.at",[],inet6,16,
             [{64635,50390,27618,36432,27800,0,0,1}]}}
```