### PR TITLE
Get a new lb pid if existing pid is not alive

### DIFF
--- a/src/ibrowse.erl
+++ b/src/ibrowse.erl
@@ -311,12 +311,7 @@ send_req(Url, Headers, Method, Body, Options, Timeout) ->
         #url{host = Host,
              port = Port,
              protocol = Protocol} = Parsed_url ->
-            Lb_pid = case ets:lookup(ibrowse_lb, {Host, Port}) of
-                         [] ->
-                             get_lb_pid(Parsed_url);
-                         [#lb_pid{pid = Lb_pid_1}] ->
-                             Lb_pid_1
-                     end,
+            Lb_pid = lb_pid(Host, Port, Parsed_url),
             Max_sessions = get_max_sessions(Host, Port, Options),
             Max_pipeline_size = get_max_pipeline_size(Host, Port, Options),
             Options_1 = merge_options(Host, Port, Options),
@@ -333,6 +328,20 @@ send_req(Url, Headers, Method, Body, Options, Timeout) ->
                                 Headers, Method, Body, Options_1, Timeout, 0);
         Err ->
             {error, {url_parsing_failed, Err}}
+    end.
+
+lb_pid(Host, Port, Url) ->
+    case ets:lookup(ibrowse_lb, {Host, Port}) of
+        [] ->
+            get_lb_pid(Url);
+        [#lb_pid{pid = Pid}] ->
+            case is_process_alive(Pid) of
+                true ->
+                    Pid;
+                false ->
+                    ets:delete(ibrowse_lb, {Host, Port}),
+                    get_lb_pid(Url)
+            end
     end.
 
 try_routing_request(Lb_pid, Parsed_url,


### PR DESCRIPTION
It's possible for the connection process associated with a pid in the
ibrowse_lb ets table to die, yet remain in the table, in which case
subsequent requests to the corresponding `{Host, Port}` will result in an
error like the following:
```
(node1@127.0.0.1)9> ibrowse:send_req("http://localhost:15984", [], get).
                ** exception exit: {noproc,
                       {gen_server,call,
                           [<0.2451.0>,
                            {spawn_connection,
                                {url,"http://localhost:15984","localhost",15984,
                                    undefined,undefined,"/",http,hostname},
                                10,10,
                                {[],false},
                                []}]}}
     in function  gen_server:call/2 (gen_server.erl, line 215)
     in call from ibrowse:try_routing_request/14 (src/ibrowse.erl, line 377)
```
This checks whether the pid about to be returned from the table is alive,
and if not, the entry is deleted, and a new pid is obtained.

This is a backport of https://github.com/cmullaparthi/ibrowse/pull/166