### PR TITLE
Unquote basic auth username and password

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -870,7 +870,9 @@ add_auth_headers(#url{username = User,
                                 [{"Authorization", ["Basic ", http_auth_digest(U, P)]} | Headers]
                         end;
                     _ ->
-                        [{"Authorization", ["Basic ", http_auth_digest(User, UPw)]} | Headers]
+                        User1 = ibrowse_lib:unquote(User),
+                        UPw1 = ibrowse_lib:unquote(UPw),
+                        [{"Authorization", ["Basic ", http_auth_digest(User1, UPw1)]} | Headers]
                 end,
     add_proxy_auth_headers(State, Headers_1).
 


### PR DESCRIPTION
Unquote username and password which were parsed by ibrowse_lib:parse_url/1 before inserting them in the basic auth header.

Previously if the user had characters like @ in their username or password, and they were percent-encoded, they were inserted encoded in the basic auth header which lead to authentication failure.

P.S.: To test this with the replicator, make sure to disable the session plugin in the "default.ini" file.
```
@@ -475,7 +475,7 @@ ssl_certificate_max_depth = 3
 ; falling back to the old basic authenticaion default:
 ;auth_plugins = couch_replicator_auth_session,couch_replicator_auth_noop
 ; To restore the old behaviour, use the following value:
-;auth_plugins = couch_replicator_auth_noop
+auth_plugins = couch_replicator_auth_noop
```