### PR TITLE
Change now/0 to timestamp/0

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -463,9 +463,14 @@ accumulate_response(Data, #state{reply_buffer      = RepBuf,
             State#state{reply_buffer = RepBuf_1}
     end.
 
+strictly_monotonic_timestamp() ->
+   {A, B, _} = erlang:timestamp(),
+   Unique = erlang:unique_integer([positive, monotonic]),
+   {A, B, Unique}.
+
 make_tmp_filename(true) ->
     DownloadDir = ibrowse:get_config_value(download_dir, filename:absname("./")),
-    {A,B,C} = now(),
+    {A,B,C} = strictly_monotonic_timestamp(),
     filename:join([DownloadDir,
                    "ibrowse_tmp_file_"++
                    integer_to_list(A) ++
@@ -1870,7 +1875,7 @@ cancel_timer(Ref, {eat_message, Msg}) ->
     end.
 
 make_req_id() ->
-    now().
+    strictly_monotonic_timestamp().
 
 to_lower(Str) ->
     to_lower(Str, []).

--- a/src/ibrowse_lib.erl
+++ b/src/ibrowse_lib.erl
@@ -375,7 +375,7 @@ default_port(ftp)    -> 21.
 
 printable_date() ->
     {{Y,Mo,D},{H, M, S}} = calendar:local_time(),
-    {_,_,MicroSecs} = now(),
+    {_,_,MicroSecs} = erlang:timestamp(),
     [integer_to_list(Y),
      $-,
      integer_to_list(Mo),

--- a/src/ibrowse_test.erl
+++ b/src/ibrowse_test.erl
@@ -80,7 +80,7 @@ load_test(Url, NumWorkers, NumReqsPerWorker) when is_list(Url),
     proc_lib:spawn(?MODULE, send_reqs_1, [Url, NumWorkers, NumReqsPerWorker]).
 
 send_reqs_1(Url, NumWorkers, NumReqsPerWorker) ->
-    Start_time = now(),
+    Start_time = erlang:timestamp(),
     ets:new(pid_table, [named_table, public]),
     ets:new(ibrowse_test_results, [named_table, public]),
     ets:new(ibrowse_errors, [named_table, public, ordered_set]),
@@ -90,7 +90,7 @@ send_reqs_1(Url, NumWorkers, NumReqsPerWorker) ->
     spawn_workers(Url, NumWorkers, NumReqsPerWorker),
     log_msg("Finished spawning workers...~n", []),
     do_wait(Url),
-    End_time = now(),
+    End_time = erlang:timestamp(),
     log_msg("All workers are done...~n", []),
     log_msg("ibrowse_test_results table: ~n~p~n", [ets:tab2list(ibrowse_test_results)]),
     log_msg("Start time: ~1000.p~n", [calendar:now_to_local_time(Start_time)]),
@@ -168,7 +168,7 @@ do_send_req_1(Url, NumReqs) ->
 	{error, retry_later} ->
 	    ets:update_counter(ibrowse_test_results, retry_later, 1);
 	Err ->
-	    ets:insert(ibrowse_errors, {now(), Err}),
+	    ets:insert(ibrowse_errors, {erlang:timestamp(), Err}),
 	    ets:update_counter(ibrowse_test_results, other_error, 1),
 	    ok
     end,
@@ -179,7 +179,7 @@ dump_errors() ->
 	0 ->
 	    ok;
 	_ ->
-	    {A, B, C} = now(),
+	    {A, B, C} = erlang:timestamp(),
 	    Filename = lists:flatten(
 			 io_lib:format("ibrowse_errors_~p_~p_~p.txt" , [A, B, C])),
 	    case file:open(Filename, [write, delayed_write, raw]) of


### PR DESCRIPTION
Change the deprecated `now/0` to `timestamp/0` to eliminate deprecation warnings during building.