### PR TITLE
Drop warnings_as_errors compile flag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [
 	   debug_info,
-	   warnings_as_errors,
 	   warn_unused_vars,
 	   nowarn_shadow_vars,
 	   warn_unused_import,


### PR DESCRIPTION
There are few expected warnings from Erlang 27 compiler for `format_status/2` callback which prevents the compilation from completing.