### PR TITLE
Replace `gen_server:format_status/2` with `format_status/1`

### DIFF
--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -34,7 +34,7 @@
          handle_info/2,
          terminate/2,
          code_change/3,
-         format_status/2
+         format_status/1
         ]).
 
 -include("ibrowse.hrl").
@@ -324,38 +324,54 @@ code_change(_OldVsn, State, _Extra) ->
 
 
 %%--------------------------------------------------------------------
-%% Function: format_status/2
+%% Function: format_status/1
 %% Purpose: Clean process state before logging
-%% Returns: key value list
+%% Returns: key value maps
 %%--------------------------------------------------------------------
-format_status(_Opt, [_PDict, State]) ->
-    #state{
-        reqs=Reqs,
-        reply_buffer=ReplyBuf,
-        recvd_headers=RCVDHeaders,
-        raw_headers=RawHeaders,
-        chunk_size_buffer=ChunkSizeBuf,
-        cur_req=Request
-    } = State,
-    ScrubbedReq = Request#request{url=url_strip_password(Request#request.url)},
-    Scrubbed = State#state{
-        reqs={queue_length, queue:len(Reqs)},
-        reply_buffer={byte_size, byte_size(ReplyBuf)},
-        recvd_headers=lists:map(fun({K, _V}) -> K end, RCVDHeaders),
-        raw_headers={byte_size, byte_size(RawHeaders)},
-        chunk_size_buffer={byte_size, byte_size(ChunkSizeBuf)},
-        cur_req=ScrubbedReq
-    },
-    [{data, [{"State",
-        lists:zip(
-            record_info(fields, state),
-            tl(tuple_to_list(Scrubbed))
-        )
-    }]}].
+format_status(Status) ->
+    maps:map(
+        fun
+            (state, State) ->
+                #state{
+                    reqs = Reqs,
+                    reply_buffer = ReplyBuf,
+                    recvd_headers = RCVDHeaders,
+                    raw_headers = RawHeaders,
+                    chunk_size_buffer = ChunkSizeBuf,
+                    cur_req = Request
+                } = State,
+                Scrubbed = State#state{
+                    reqs = {queue_length, queue:len(Reqs)},
+                    reply_buffer = {byte_size, get_size(ReplyBuf)},
+                    recvd_headers = lists:map(fun({K, _V}) -> K end, RCVDHeaders),
+                    raw_headers = {byte_size, get_size(RawHeaders)},
+                    chunk_size_buffer = {byte_size, get_size(ChunkSizeBuf)},
+                    cur_req = scrub_req(Request)
+                },
+                maps:from_list(
+                    lists:zip(
+                        record_info(fields, state),
+                        tl(tuple_to_list(Scrubbed))
+                    )
+                );
+            (_, Value) ->
+                Value
+        end,
+        Status
+    ).
 
 %%--------------------------------------------------------------------
 %%% Internal functions
 %%--------------------------------------------------------------------
+get_size(RawData) when is_binary(RawData) ->
+    byte_size(RawData);
+get_size(_) ->
+    0.
+
+scrub_req(#request{} = Req) ->
+    Req#request{url = url_strip_password(Req#request.url)};
+scrub_req(Other) ->
+    Other.
 
 url_strip_password(Url) ->
     re:replace(Url,


### PR DESCRIPTION
`gen_server:format_status/2` is deprecated and will be replaced by
`format_status(#{})`.

Fix the following warnings:

```log
[2025-09-17T13:01:35.309Z] /home/jenkins/workspace/next-multibranch-pipeline_otp-27/src/ibrowse/src/ibrowse_http_client.erl:9:2: Warning: the callback gen_server:format_status(_,_) is deprecated; use format_status/1 instead
```

Related PR:
- OTP: https://github.com/erlang/otp/pull/4952
- CouchDB: https://github.com/apache/couchdb/pull/5666