### PR TITLE
feat: add connect_to option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [
 	   debug_info,
-	   warnings_as_errors,
 	   warn_unused_vars,
 	   nowarn_shadow_vars,
 	   warn_unused_import,

--- a/src/ibrowse_http_client.erl
+++ b/src/ibrowse_http_client.erl
@@ -618,13 +618,18 @@ do_connect(Host, Port, Options, #state{is_ssl      = true,
                                        use_proxy   = false,
                                        ssl_options = SSLOptions},
            Timeout) ->
+    %% Check for connect_to override and remove from options
+    Host1 = get_value(connect_to, Options, Host),
+    Options1 = proplists:delete(connect_to, Options),
+    
     %% if a socks5 proxy is configured, open the socket separately
     %% before upgrading the socket to a TLS connection.
-    case get_value(socks5_host, Options, undefined) of
+    case get_value(socks5_host, Options1, undefined) of
         %% no socks5 proxy is configured, connect directly with TLS:
         undefined ->
-            Sock_options = get_sock_options(Host, Options, SSLOptions),
-            ssl:connect(Host, Port, Sock_options, Timeout);
+            Sock_options = get_sock_options(Host, Options1, SSLOptions),
+            Sock_options1 = ensure_sni(Sock_options, Host),
+            ssl:connect(Host1, Port, Sock_options1, Timeout);
 
         %% proxy configuration is present: first establish a socket
         %% and then upgrade:
@@ -641,13 +646,17 @@ do_connect(Host, Port, Options, #state{is_ssl      = true,
     end;
 
 do_connect(Host, Port, Options, _State, Timeout) ->
-    Socks5Host = get_value(socks5_host, Options, undefined),
-    Sock_options = get_sock_options(Host, Options, []),
+    %% Check for connect_to override and remove from options
+    Host1 = get_value(connect_to, Options, Host),
+    Options1 = proplists:delete(connect_to, Options),
+    
+    Socks5Host = get_value(socks5_host, Options1, undefined),
+    Sock_options = get_sock_options(Host, Options1, []),
     case Socks5Host of
       undefined ->
-        gen_tcp:connect(Host, Port, Sock_options, Timeout);
+        gen_tcp:connect(Host1, Port, Sock_options, Timeout);
       _ ->
-        catch ibrowse_socks5:connect(Host, Port, Options, Sock_options, Timeout)
+        catch ibrowse_socks5:connect(Host1, Port, Options1, Sock_options, Timeout)
     end.
 
 get_sock_options(Host, Options, SSLOptions) ->
@@ -695,9 +704,19 @@ filter_sock_options(Opts) ->
                          false;
                     (list) ->
                          false;
+
                     (_) ->
                          true
                  end, Opts).
+
+%% Ensure SNI is set for SSL connections when using connect_to override
+ensure_sni(Opts, Host) ->
+    case lists:keyfind(server_name_indication, 1, Opts) of
+        false ->
+            [{server_name_indication, Host} | Opts];
+        _ ->
+            Opts
+    end.
 
 do_send(Req, #state{socket = Sock,
                     is_ssl = true,

--- a/test/ibrowse_test.erl
+++ b/test/ibrowse_test.erl
@@ -40,7 +40,8 @@
 	 test_save_to_file_no_content_length/0,
          socks5_noauth/0,
          socks5_auth_succ/0,
-         socks5_auth_fail/0
+         socks5_auth_fail/0,
+         test_dead_lb_pid/0
 	]).
 
 -include_lib("ibrowse/include/ibrowse.hrl").
@@ -64,7 +65,8 @@
                       {local_test_fun, test_retry_of_requests, []},
 		      {local_test_fun, verify_chunked_streaming, []},
 		      {local_test_fun, test_chunked_streaming_once, []},
-		      {local_test_fun, test_generate_body_0, []}
+		      {local_test_fun, test_generate_body_0, []},
+		      {local_test_fun, test_dead_lb_pid, []}
                      ]).
 
 -define(TEST_LIST, [{"http://intranet/messenger", get},
@@ -876,6 +878,22 @@ test_generate_body_0() ->
     after
         ets:delete(Tid)
     end.
+
+%% Test that when an lb process dies, its entry is removed from the ibrowse_lb
+%% table by the next requestor and replaced with a new process
+%%------------------------------------------------------------------------------
+test_dead_lb_pid() ->
+    {Host, Port} = {"localhost", 8181},
+    Url = "http://" ++ Host ++ ":" ++ integer_to_list(Port),
+    {ok, "200", _, _} = ibrowse:send_req(Url, [], get),
+    [{lb_pid, {Host, Port}, Pid, _}] = ets:lookup(ibrowse_lb, {Host, Port}),
+    true = exit(Pid, kill),
+    false = is_process_alive(Pid),
+    {ok, "200", _, _} = ibrowse:send_req(Url, [], get),
+    [{lb_pid, {Host, Port}, NewPid, _}] = ets:lookup(ibrowse_lb, {Host, Port}),
+    true = NewPid /= Pid,
+    true = is_process_alive(NewPid),
+    success.
 
 do_trace(Fmt, Args) ->
     do_trace(get(my_trace_flag), Fmt, Args).


### PR DESCRIPTION
Add a `connect_to` request option that lets
ibrowse connect to a different network target
while preserving the original URL host for Host
handling, cookies, and TLS SNI.

The use case for this is when connecting through
a transparent SNI proxy for egress control.